### PR TITLE
feat(recursos): Buscar por Id, crear (parcialmente), editar y eliminar

### DIFF
--- a/src/main/java/com/recolectaedu/controller/RecursoController.java
+++ b/src/main/java/com/recolectaedu/controller/RecursoController.java
@@ -1,12 +1,17 @@
 package com.recolectaedu.controller;
 
+import com.recolectaedu.dto.request.RecursoCreateRequestDTO;
+import com.recolectaedu.dto.request.RecursoPartialUpdateRequestDTO;
+import com.recolectaedu.dto.request.RecursoUpdateRequestDTO;
 import com.recolectaedu.dto.response.RecursoResponseDTO;
 import com.recolectaedu.dto.response.RecursoValoradoResponseDTO;
 import com.recolectaedu.service.RecursoService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -42,5 +47,42 @@ public class RecursoController {
             @PathVariable("id_curso") Integer id_curso
     ) {
         return ResponseEntity.ok(recursoService.obtenerRecursosMasValoradosPorCurso(id_curso));
+    }
+
+    @PostMapping
+    public ResponseEntity<RecursoResponseDTO> crear(
+            @Valid @RequestBody RecursoCreateRequestDTO request
+    ) {
+        RecursoResponseDTO creado = recursoService.crear(request);
+        return ResponseEntity.created(URI.create("/recursos/" + creado.getId_recurso())).body(creado);
+    }
+
+    @GetMapping("/{id_recurso}")
+    public ResponseEntity<RecursoResponseDTO> obtener(
+            @PathVariable
+            Integer id_recurso) {
+        return ResponseEntity.ok(recursoService.obtenerPorId(id_recurso));
+    }
+
+    @PutMapping("/{id_recurso}")
+    public ResponseEntity<RecursoResponseDTO> actualizar(
+            @PathVariable Integer id_recurso,
+            @Valid @RequestBody RecursoUpdateRequestDTO request) {
+        return ResponseEntity.ok(recursoService.actualizar(id_recurso, request));
+    }
+
+    @PatchMapping("/{id_recurso}")
+    public ResponseEntity<RecursoResponseDTO> actualizarParcial(
+            @PathVariable Integer id_recurso,
+            @RequestBody RecursoPartialUpdateRequestDTO request) {
+        return ResponseEntity.ok(recursoService.actualizarParcial(id_recurso, request));
+    }
+
+    @DeleteMapping("/{id_recurso}")
+    public ResponseEntity<Void> eliminar(
+            @PathVariable Integer id_recurso
+    ) {
+        recursoService.eliminar(id_recurso);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/recolectaedu/dto/request/RecursoCreateRequestDTO.java
+++ b/src/main/java/com/recolectaedu/dto/request/RecursoCreateRequestDTO.java
@@ -1,0 +1,31 @@
+package com.recolectaedu.dto.request;
+
+import com.recolectaedu.model.enums.FormatoRecurso;
+import com.recolectaedu.model.enums.Tipo_recurso;
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+
+@Builder
+public record RecursoCreateRequestDTO(
+        @NotNull
+        Integer id_usuario,
+        @NotNull
+        Integer id_curso,
+        @NotBlank
+        @Size(max = 255)
+        String titulo,
+        @NotBlank
+        String descripcion,
+        @NotBlank
+        String contenido,
+        @NotNull
+        FormatoRecurso formato,
+        @NotNull
+        Tipo_recurso tipo,
+        @NotNull
+        @Min(1900) @Max(2100)
+        Integer ano,
+        @NotNull
+        Integer periodo
+) {
+}

--- a/src/main/java/com/recolectaedu/dto/request/RecursoPartialUpdateRequestDTO.java
+++ b/src/main/java/com/recolectaedu/dto/request/RecursoPartialUpdateRequestDTO.java
@@ -1,0 +1,29 @@
+package com.recolectaedu.dto.request;
+
+import com.recolectaedu.model.enums.FormatoRecurso;
+import com.recolectaedu.model.enums.Tipo_recurso;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+@Builder
+public record RecursoPartialUpdateRequestDTO(
+        @Nullable
+        Integer id_curso,
+        @Nullable
+        @Size(max = 255)
+        String titulo,
+        @Nullable
+        String descripcion,
+        @Nullable
+        String contenido,
+        @Nullable
+        FormatoRecurso formato,
+        @Nullable
+        Tipo_recurso tipo,
+        @Nullable
+        Integer ano,
+        @Nullable
+        Integer periodo
+) {
+}

--- a/src/main/java/com/recolectaedu/dto/request/RecursoUpdateRequestDTO.java
+++ b/src/main/java/com/recolectaedu/dto/request/RecursoUpdateRequestDTO.java
@@ -1,0 +1,29 @@
+package com.recolectaedu.dto.request;
+
+import com.recolectaedu.model.enums.FormatoRecurso;
+import com.recolectaedu.model.enums.Tipo_recurso;
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+
+@Builder
+public record RecursoUpdateRequestDTO(
+        @NotNull
+        Integer id_curso,
+        @NotBlank
+        @Size(max = 255)
+        String titulo,
+        @NotBlank
+        String descripcion,
+        @NotBlank
+        String contenido,
+        @NotNull
+        FormatoRecurso formato,
+        @NotNull
+        Tipo_recurso tipo,
+        @NotNull
+        @Min(1900) @Max(2100)
+        Integer ano,
+        @NotNull
+        Integer periodo
+) {
+}

--- a/src/main/java/com/recolectaedu/model/enums/Periodo.java
+++ b/src/main/java/com/recolectaedu/model/enums/Periodo.java
@@ -1,5 +1,8 @@
 package com.recolectaedu.model.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum Periodo {
     verano(0),
     primer(1),
@@ -11,7 +14,4 @@ public enum Periodo {
         this.valor = valor;
     }
 
-    public int getValor() {
-        return valor;
-    }
 }

--- a/src/main/java/com/recolectaedu/service/UsuarioService.java
+++ b/src/main/java/com/recolectaedu/service/UsuarioService.java
@@ -104,6 +104,7 @@ public class UsuarioService {
         } catch (IllegalArgumentException ex) {
             throw new BusinessRuleException("Rol inválido. Permitidos: FREE, PREMIUM, ADMIN.");
         }
+    }
       
      //GET stats 
     @Transactional(readOnly = true)


### PR DESCRIPTION
### Descripción

- US-07 - Editar o eliminar un recurso propio publicado
- US-05 - Publica recurso (parcialmente)

Este pull request introduce funcionalidad CRUD (Crear, Leer, Actualizar, Eliminar) para la gestión de recursos. Incluye los siguientes cambios:

- **Actualizaciones del controlador**: Se añadieron endpoints en `RecursoController` para manejar la creación, obtención, actualización (completa y parcial) y eliminación de recursos, con validación de datos y ruteo adecuado.
- **Actualizaciones de la capa de servicio**: Se implementaron métodos en `RecursoService` para soportar las operaciones CRUD, incluyendo conversión de DTO y validación de entidades relacionadas (`Usuario`, `Curso`).
- **Adición de DTOs**: Se crearon DTOs específicos (`RecursoCreateRequestDTO`, `RecursoUpdateRequestDTO`, `RecursoPartialUpdateRequestDTO`) para manejar solicitudes entrantes con patrones de builder y validaciones.
- **Actualización del modelo**: Se añadió la anotación `@Getter` de Lombok a `Periodo`, eliminando la necesidad de un getter definido manualmente.
- **Corrección de bug**: Se resolvió un problema de corchete de cierre faltante en la entidad `Usuario`.