### PR TITLE
feat(cursos): Implementa ranking de cursos por aportes (US18)

### DIFF
--- a/src/main/java/com/recolectaedu/controller/CursoController.java
+++ b/src/main/java/com/recolectaedu/controller/CursoController.java
@@ -1,11 +1,16 @@
 package com.recolectaedu.controller;
 
+import com.recolectaedu.dto.response.CursoRankingAportesDTO;
 import com.recolectaedu.dto.response.CursoResponseDTO;
 import com.recolectaedu.service.CursoService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -21,6 +26,18 @@ public class CursoController {
     @GetMapping("/populares")
     public ResponseEntity<List<CursoResponseDTO>> findCursosPopulares() {
         List<CursoResponseDTO> response = cursoService.findCursosPopulares();
+        return ResponseEntity.ok(response);
+    }
+
+    //US18 - Ranking de cursos con mas aportes
+    @GetMapping("/ranking-aportes")
+    public ResponseEntity<Page<CursoRankingAportesDTO>> getRankingAportes(
+            @RequestParam(required = false) String universidad,
+            @RequestParam(required = false) String carrera,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<CursoRankingAportesDTO> response = cursoService.getRankingAportes(universidad, carrera, pageable);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/recolectaedu/dto/response/CursoRankingAportesDTO.java
+++ b/src/main/java/com/recolectaedu/dto/response/CursoRankingAportesDTO.java
@@ -1,0 +1,38 @@
+package com.recolectaedu.dto.response;
+
+public class CursoRankingAportesDTO {
+
+    private Integer idCurso;
+    private String nombre;
+    private String universidad;
+    private String carrera;
+    private Long aportesCount;
+
+    public CursoRankingAportesDTO(Integer idCurso, String nombre, String universidad, String carrera, Long aportesCount) {
+        this.idCurso = idCurso;
+        this.nombre = nombre;
+        this.universidad = universidad;
+        this.carrera = carrera;
+        this.aportesCount = aportesCount;
+    }
+
+    public Integer getIdCurso() {
+        return idCurso;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public String getUniversidad() {
+        return universidad;
+    }
+
+    public String getCarrera() {
+        return carrera;
+    }
+
+    public Long getAportesCount() {
+        return aportesCount;
+    }
+}

--- a/src/main/java/com/recolectaedu/repository/CursoRepository.java
+++ b/src/main/java/com/recolectaedu/repository/CursoRepository.java
@@ -1,9 +1,13 @@
 package com.recolectaedu.repository;
 
+import com.recolectaedu.dto.response.CursoRankingAportesDTO;
 import com.recolectaedu.dto.response.CursoResponseDTO;
 import com.recolectaedu.model.Curso;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -17,5 +21,14 @@ public interface CursoRepository extends JpaRepository<Curso, Integer> {
             "GROUP BY c.id_curso, c.universidad, c.nombre, c.carrera " +
             "ORDER BY COUNT(r) DESC")
     List<CursoResponseDTO> findCursosPopulares();
+
+    @Query("SELECT new com.recolectaedu.dto.response.CursoRankingAportesDTO(" +
+            "c.id, c.nombre, c.universidad, c.carrera, COUNT(r)) " +
+            "FROM Curso c LEFT JOIN Recurso r ON r.curso = c " +
+            "WHERE (:universidad IS NULL OR c.universidad = :universidad) " +
+            "AND (:carrera IS NULL OR c.carrera = :carrera) " +
+            "GROUP BY c.id, c.nombre, c.universidad, c.carrera " +
+            "ORDER BY COUNT(r) DESC")
+    Page<CursoRankingAportesDTO> rankingPorAportes(@Param("universidad") String universidad, @Param("carrera") String carrera, Pageable pageable);
 
 }

--- a/src/main/java/com/recolectaedu/service/CursoService.java
+++ b/src/main/java/com/recolectaedu/service/CursoService.java
@@ -1,9 +1,13 @@
 package com.recolectaedu.service;
 
+import com.recolectaedu.dto.response.CursoRankingAportesDTO;
 import com.recolectaedu.dto.response.CursoResponseDTO;
 import com.recolectaedu.repository.CursoRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -16,6 +20,12 @@ public class CursoService {
 
     public List<CursoResponseDTO> findCursosPopulares() {
         return cursoRepository.findCursosPopulares();
+    }
+
+    public Page<CursoRankingAportesDTO> getRankingAportes(String universidad, String carrera, Pageable pageable) {
+        String universidadParam = StringUtils.hasText(universidad) ? universidad : null;
+        String carreraParam = StringUtils.hasText(carrera) ? carrera : null;
+        return cursoRepository.rankingPorAportes(universidadParam, carreraParam, pageable);
     }
 
 }

--- a/src/test/java/com/recolectaedu/controller/CursoControllerTest.java
+++ b/src/test/java/com/recolectaedu/controller/CursoControllerTest.java
@@ -1,0 +1,27 @@
+package com.recolectaedu.controller;
+
+import com.recolectaedu.service.CursoService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CursoController.class)
+public class CursoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CursoService cursoService;
+
+    @Test
+    void testGetRankingAportes() throws Exception {
+        mockMvc.perform(get("/cursos/ranking-aportes"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/recolectaedu/repository/CursoRepositoryTest.java
+++ b/src/test/java/com/recolectaedu/repository/CursoRepositoryTest.java
@@ -1,0 +1,25 @@
+package com.recolectaedu.repository;
+
+import com.recolectaedu.dto.response.CursoRankingAportesDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class CursoRepositoryTest {
+
+    @Autowired
+    private CursoRepository cursoRepository;
+
+    @Test
+    void testRankingPorAportes() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<CursoRankingAportesDTO> result = cursoRepository.rankingPorAportes(null, null, pageable);
+        assertThat(result).isNotNull();
+    }
+}


### PR DESCRIPTION
Se añade la funcionalidad para obtener un ranking paginado de cursos basado en la cantidad de recursos asociados.

- Crea el DTO CursoRankingAportesDTO.
- Extiende el repositorio con una consulta JPQL para agregar y contar los aportes.
- Implementa la lógica en el servicio y expone el endpoint GET /cursos/ranking-aportes.
- Incluye pruebas básicas para el repositorio y el controlador.