### PR TITLE
US08: feat - Implementar historial de aportes de usuario

### DIFF
--- a/src/main/java/com/recolectaedu/controller/UsuarioController.java
+++ b/src/main/java/com/recolectaedu/controller/UsuarioController.java
@@ -2,53 +2,55 @@ package com.recolectaedu.controller;
 
 import com.recolectaedu.dto.request.PerfilRequestDTO;
 import com.recolectaedu.dto.request.UserRequestDTO;
-import com.recolectaedu.dto.response.UsuarioStatsResponseDTO;
-import com.recolectaedu.model.Usuario;
+import com.recolectaedu.dto.response.AporteListadoResponseDTO;
+import com.recolectaedu.dto.response.RespuestaPagina;
 import com.recolectaedu.dto.response.UserResponseDTO;
+import com.recolectaedu.dto.response.UsuarioStatsResponseDTO;
+import com.recolectaedu.service.RecursoService;
 import com.recolectaedu.service.UsuarioService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-// Por hacer: devolver un ResponseDTO sin password_hash
 @RestController
 @RequestMapping("/usuarios")
 @RequiredArgsConstructor
 public class UsuarioController {
 
     private final UsuarioService usuarioService;
+    private final RecursoService recursoService;
 
-    //POST /usuarios/register
     @PostMapping(value = "/register", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<UserResponseDTO> register(@Valid @RequestBody UserRequestDTO req) {
-        var resp = usuarioService.registrarUsuario(req); // que devuelva UserResponseDTO
+        var resp = usuarioService.registrarUsuario(req);
         return ResponseEntity.status(HttpStatus.CREATED).body(resp);
     }
 
-    // GET /usuarios/{id}
     @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<UserResponseDTO> getById(@PathVariable Integer id) {
         var resp = usuarioService.obtenerUsuarioPorIdDTO(id);
-        return ResponseEntity.ok(resp); // 200
+        return ResponseEntity.ok(resp);
     }
 
-    // PUT /usuarios/{id}/profile
     @PutMapping(value = "/{id}/profile", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<UserResponseDTO> upsertProfile(
             @PathVariable Integer id,
             @Valid @RequestBody PerfilRequestDTO body) {
         var resp = usuarioService.actualizarPerfilDTO(id, body);
-        return ResponseEntity.ok(resp); // 200
+        return ResponseEntity.ok(resp);
     }
 
-    // DELETE /usuarios/{id}
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Integer id) {
         usuarioService.eliminarUsuario(id);
-        return ResponseEntity.noContent().build(); // 204
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/{id_usuario}/estadisticas")
@@ -56,5 +58,37 @@ public class UsuarioController {
             @PathVariable Integer id_usuario
     ) {
         return ResponseEntity.ok(usuarioService.obtenerEstadisticas(id_usuario));
+    }
+
+    // US-08: Historial de aportes de un usuario
+    @GetMapping("/{usuarioId}/aportes")
+    public ResponseEntity<RespuestaPagina<AporteListadoResponseDTO>> getAportesPorUsuario(
+            @PathVariable Integer usuarioId,
+            @RequestParam(required = false) Integer cursoId,
+            @RequestParam(required = false) String tipo,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "creado_el,desc") String[] sort
+    ) {
+        Sort.Direction direction = sort[1].equalsIgnoreCase("asc") ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sort[0]));
+
+        Page<AporteListadoResponseDTO> aportesPage = recursoService.listarMisAportes(
+                usuarioId,
+                cursoId,
+                tipo,
+                pageable
+        );
+
+        RespuestaPagina<AporteListadoResponseDTO> respuesta = new RespuestaPagina<>(
+                aportesPage.getContent(),
+                aportesPage.getNumber(),
+                aportesPage.getSize(),
+                aportesPage.getTotalElements(),
+                aportesPage.getTotalPages(),
+                aportesPage.isLast()
+        );
+
+        return ResponseEntity.ok(respuesta);
     }
 }

--- a/src/main/java/com/recolectaedu/dto/response/AporteListadoResponseDTO.java
+++ b/src/main/java/com/recolectaedu/dto/response/AporteListadoResponseDTO.java
@@ -1,0 +1,22 @@
+package com.recolectaedu.dto.response;
+
+import com.recolectaedu.model.enums.Tipo_recurso;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AporteListadoResponseDTO {
+    private Integer id;
+    private String titulo;
+    private Tipo_recurso tipo;
+    private Integer cursoId;
+    private String cursoNombre;
+    private String universidad;
+    private LocalDateTime fechaCreacion;
+    private LocalDateTime fechaActualizacion;
+}

--- a/src/main/java/com/recolectaedu/dto/response/RespuestaPagina.java
+++ b/src/main/java/com/recolectaedu/dto/response/RespuestaPagina.java
@@ -1,0 +1,19 @@
+package com.recolectaedu.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RespuestaPagina<T> {
+    private List<T> contenido;
+    private int pagina;
+    private int tamanio;
+    private long totalElementos;
+    private int totalPaginas;
+    private boolean ultimo;
+}


### PR DESCRIPTION
Este Pull Request introduce la funcionalidad completa para la US-08, que permite a los clientes del API consultar el historial de aportes (recursos) creados por un usuario específico.

Se implementa un nuevo endpoint GET /api/v1/usuarios/{usuarioId}/aportes que soporta:
•Paginación (page, size).
•Filtros opcionales por cursoId y tipo de recurso.
•Ordenación por defecto por fecha de creación descendente.
