### PR TITLE
feat(register-subscription): CRUD y lógica de Membresía + relación co…

### DIFF
--- a/src/main/java/com/recolectaedu/controller/MembresiaController.java
+++ b/src/main/java/com/recolectaedu/controller/MembresiaController.java
@@ -1,0 +1,49 @@
+package com.recolectaedu.controller;
+
+import com.recolectaedu.dto.request.MembresiaRequestDTO;
+import com.recolectaedu.dto.response.MembresiaResponseDTO;
+import com.recolectaedu.service.MembresiaService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/usuarios/{idUsuario}/membresias")
+@RequiredArgsConstructor
+public class MembresiaController {
+
+    private final MembresiaService membresiaService;
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<MembresiaResponseDTO> create(
+            @PathVariable Integer idUsuario,
+            @Valid @RequestBody MembresiaRequestDTO req) {
+        var resp = membresiaService.create(idUsuario, req);
+        return ResponseEntity.status(201).body(resp);
+    }
+
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<MembresiaResponseDTO>> list(@PathVariable Integer idUsuario) {
+        var resp = membresiaService.list(idUsuario);
+        return ResponseEntity.ok(resp);
+    }
+
+    @PutMapping(value = "/cancelar", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<MembresiaResponseDTO> cancelActive(
+            @PathVariable Integer idUsuario) {
+        var resp = membresiaService.cancelActive(idUsuario);
+        return ResponseEntity.ok(resp);
+    }
+
+    @PutMapping(value = "/{idMembresia}/cancelar", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<MembresiaResponseDTO> cancel(
+            @PathVariable Integer idUsuario) {
+        var resp = membresiaService.cancelActive(idUsuario);
+        return ResponseEntity.status(HttpStatus.OK).body(resp);
+    }
+}

--- a/src/main/java/com/recolectaedu/dto/request/MembresiaRequestDTO.java
+++ b/src/main/java/com/recolectaedu/dto/request/MembresiaRequestDTO.java
@@ -1,0 +1,9 @@
+package com.recolectaedu.dto.request;
+
+import com.recolectaedu.model.enums.Plan;
+import jakarta.validation.constraints.NotNull;
+
+public record MembresiaRequestDTO(
+        @NotNull Plan plan,   // MONTHLY o ANNUAL
+        boolean autoRenew     // true/false
+) {}

--- a/src/main/java/com/recolectaedu/dto/response/MembresiaResponseDTO.java
+++ b/src/main/java/com/recolectaedu/dto/response/MembresiaResponseDTO.java
@@ -1,0 +1,15 @@
+package com.recolectaedu.dto.response;
+
+import com.recolectaedu.model.enums.MembresiaStatus;
+import com.recolectaedu.model.enums.Plan;
+
+import java.time.Instant;
+
+public record MembresiaResponseDTO(
+        Integer id,
+        Plan plan,
+        MembresiaStatus status,
+        boolean autoRenew,
+        Instant startsAt,
+        Instant endsAt
+) {}

--- a/src/main/java/com/recolectaedu/model/Membresia.java
+++ b/src/main/java/com/recolectaedu/model/Membresia.java
@@ -1,16 +1,18 @@
 package com.recolectaedu.model;
 
-
+import com.recolectaedu.model.enums.MembresiaStatus;
 import com.recolectaedu.model.enums.Plan;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
-@Data
 @Entity
-@Table(name = "Membresía")
+@Table(name = "membresia",
+        indexes = {
+                @Index(name = "idx_membresia_usuario", columnList = "id_usuario"),
+                @Index(name = "idx_membresia_status", columnList = "status")
+        })
 @Getter
 @Setter
 @NoArgsConstructor
@@ -20,22 +22,27 @@ public class Membresia {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id_membresia;
+    private Integer id;
+
+    // Usuario 1:N Membresia
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "id_usuario", nullable = false, foreignKey = @ForeignKey(name = "fk_membresia_usuario"))
+    private Usuario usuario;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Plan tipo;
+    @Column(nullable = false, length = 20)
+    private MembresiaStatus status; // PENDING/ACTIVE/CANCELED/EXPIRED
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Plan plan; // MONTHLY/ANNUAL
 
     @Column(nullable = false)
-    private Boolean es_activo;
+    private Instant startsAt;
 
     @Column(nullable = false)
-    private LocalDateTime empieza_el;
+    private Instant endsAt;
 
     @Column(nullable = false)
-    private LocalDateTime termina_el;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "id_usuario", nullable = false)
-    private Usuario usuario;
+    private boolean autoRenew;
 }

--- a/src/main/java/com/recolectaedu/model/Usuario.java
+++ b/src/main/java/com/recolectaedu/model/Usuario.java
@@ -38,4 +38,23 @@ public class Usuario {
             perfil.setUsuario(this);
         }
     }
+
+    // Relación 1:N con Membresia y hook
+    @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
+    private java.util.List<Membresia> membresias = new java.util.ArrayList<>();
+
+    public void addMembresia(Membresia m) {
+        if (m != null) {
+            m.setUsuario(this);
+            this.membresias.add(m);
+        }
+    }
+
+    public void removeMembresia(Membresia m) {
+        if (m != null) {
+            m.setUsuario(null);
+            this.membresias.remove(m);
+        }
+    }
+
 }

--- a/src/main/java/com/recolectaedu/model/enums/MembresiaStatus.java
+++ b/src/main/java/com/recolectaedu/model/enums/MembresiaStatus.java
@@ -1,0 +1,8 @@
+package com.recolectaedu.model.enums;
+
+public enum MembresiaStatus {
+    PENDING,
+    ACTIVE,
+    CANCELED,
+    EXPIRED
+}

--- a/src/main/java/com/recolectaedu/model/enums/Plan.java
+++ b/src/main/java/com/recolectaedu/model/enums/Plan.java
@@ -1,6 +1,6 @@
 package com.recolectaedu.model.enums;
 
 public enum Plan {
-    Mensual,
-    Anual
+    MONTHLY,
+    ANNUAL
 }

--- a/src/main/java/com/recolectaedu/repository/MembresiaRepository.java
+++ b/src/main/java/com/recolectaedu/repository/MembresiaRepository.java
@@ -1,7 +1,65 @@
 package com.recolectaedu.repository;
 
 import com.recolectaedu.model.Membresia;
-import org.springframework.data.jpa.repository.JpaRepository;
+import com.recolectaedu.model.enums.MembresiaStatus;
+import com.recolectaedu.model.enums.Plan;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.*;
 
 public interface MembresiaRepository extends JpaRepository<Membresia, Integer> {
+
+    @Query("""
+       SELECT (COUNT(m) > 0)
+       FROM Membresia m
+       WHERE m.usuario.id_usuario = :idUsuario
+         AND m.status = com.recolectaedu.model.enums.MembresiaStatus.ACTIVE
+         AND m.startsAt < :now AND m.endsAt > :now
+       """)
+    boolean hasAnyActiveNow(@Param("idUsuario") Integer idUsuario,
+                            @Param("now") java.time.Instant now);
+
+    @Query("""
+       SELECT m
+       FROM Membresia m
+       WHERE m.usuario.id_usuario = :idUsuario
+         AND m.status = com.recolectaedu.model.enums.MembresiaStatus.ACTIVE
+         AND m.startsAt < :now AND m.endsAt > :now
+       ORDER BY m.startsAt DESC
+       """)
+    java.util.List<Membresia> findAllActiveNowOrderByStartsDesc(@Param("idUsuario") Integer idUsuario,
+                                                                @Param("now") java.time.Instant now);
+
+    @Query("""
+       SELECT m
+       FROM Membresia m
+       WHERE m.usuario.id_usuario = :idUsuario
+         AND m.status = com.recolectaedu.model.enums.MembresiaStatus.ACTIVE
+         AND m.startsAt < :now AND m.endsAt > :now
+       """)
+    Optional<Membresia> findActiveNowByUsuario(@Param("idUsuario") Integer idUsuario,
+                                               @Param("now") Instant now);
+
+    @Query("""
+           SELECT (COUNT(m) > 0)
+           FROM Membresia m
+           WHERE m.usuario.id_usuario = :idUsuario
+             AND m.status = com.recolectaedu.model.enums.MembresiaStatus.ACTIVE
+             AND m.startsAt < :now AND m.endsAt > :now
+           """)
+    boolean hasActiveMembership(@Param("idUsuario") Integer idUsuario,
+                                @Param("now") Instant now);
+
+    @Query("""
+           SELECT m
+           FROM Membresia m
+           WHERE m.usuario.id_usuario = :idUsuario
+           ORDER BY m.startsAt DESC
+           """)
+    List<Membresia> findAllByUsuarioOrderByStartsDesc(@Param("idUsuario") Integer idUsuario);
+
+    // 🔹 Para expirar en batch: no hay nested, se puede método derivado
+    List<Membresia> findByStatusAndEndsAtBefore(MembresiaStatus status, Instant now);
 }

--- a/src/main/java/com/recolectaedu/service/MembresiaService.java
+++ b/src/main/java/com/recolectaedu/service/MembresiaService.java
@@ -1,0 +1,138 @@
+package com.recolectaedu.service;
+
+import com.recolectaedu.dto.request.MembresiaRequestDTO;
+import com.recolectaedu.dto.response.MembresiaResponseDTO;
+import com.recolectaedu.exception.BusinessRuleException;
+import com.recolectaedu.exception.ResourceNotFoundException;
+import com.recolectaedu.model.Membresia;
+import com.recolectaedu.model.Usuario;
+import com.recolectaedu.model.enums.Rol;
+import com.recolectaedu.model.enums.MembresiaStatus;
+import com.recolectaedu.repository.MembresiaRepository;
+import com.recolectaedu.repository.UsuarioRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class MembresiaService {
+
+    private final UsuarioRepository usuarioRepository;
+    private final MembresiaRepository membresiaRepository;
+
+    @Transactional
+    public MembresiaResponseDTO create(Integer idUsuario, MembresiaRequestDTO req) {
+        Usuario user = usuarioRepository.findById(idUsuario)
+                .orElseThrow(() -> new ResourceNotFoundException("Usuario no encontrado"));
+
+        // no más de una membresia ACTIVE vigente por plan
+        // MembresiaService.create(...)
+        if (membresiaRepository.hasAnyActiveNow(idUsuario, Instant.now())) {
+            throw new BusinessRuleException("Ya existe una membresía activa vigente para este usuario");
+        }
+
+
+        Instant starts = Instant.now();
+        ZonedDateTime nowUtc = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime endsUtc = switch (req.plan()) {
+            case MONTHLY -> nowUtc.plusMonths(1);
+            case ANNUAL  -> nowUtc.plusYears(1);
+        };
+        Instant ends = endsUtc.toInstant();
+
+        Membresia m = Membresia.builder()
+                .usuario(user)
+                .plan(req.plan())
+                .status(MembresiaStatus.ACTIVE) // simulacion pago exitoso
+                .autoRenew(req.autoRenew())
+                .startsAt(starts)
+                .endsAt(ends)
+                .build();
+
+        m = membresiaRepository.save(m);
+
+        syncUserRole(user); // sincroniza el rol del usuario
+
+        return toDTO(m);
+    }
+
+    @Transactional
+    public MembresiaResponseDTO cancelActive(Integer idUsuario) {
+        var actives = membresiaRepository.findAllActiveNowOrderByStartsDesc(idUsuario, Instant.now());
+        if (actives.isEmpty()) {
+            throw new BusinessRuleException("El usuario no tiene una membresía activa vigente");
+        }
+
+        var m = actives.getFirst();
+
+        // desactivar autoRenew, cerrar vigencia y marcar estado
+        m.setAutoRenew(false);
+        m.setEndsAt(Instant.now());
+        m.setStatus(MembresiaStatus.CANCELED);
+        m = membresiaRepository.save(m);
+
+        // Sincroniza rol del usuario (pasar a FREE)
+        return toDTO(m);
+    }
+
+    @Transactional
+    public int expireOverdue() {
+        Instant now = Instant.now();
+        // ACTIVE cuyo endsAt ya expiró
+        var vencidas = membresiaRepository.findByStatusAndEndsAtBefore(MembresiaStatus.ACTIVE, now);
+        if (vencidas.isEmpty()) return 0;
+
+        // Pasar a EXPIRED y recolectar usuarios afectados
+        Set<Integer> usuariosAfectados = new HashSet<>();
+        for (Membresia m : vencidas) {
+            m.setStatus(MembresiaStatus.EXPIRED);
+            usuariosAfectados.add(m.getUsuario().getId_usuario());
+        }
+        membresiaRepository.saveAll(vencidas);
+
+        // Sincronizar rol por cada usuario
+        for (Integer uid : usuariosAfectados) {
+            usuarioRepository.findById(uid).ifPresent(this::syncUserRole);
+        }
+        return vencidas.size();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MembresiaResponseDTO> list(Integer idUsuario) {
+        // asegura que el usuario existe
+        usuarioRepository.findById(idUsuario)
+                .orElseThrow(() -> new ResourceNotFoundException("Usuario no encontrado"));
+
+        return membresiaRepository.findAllByUsuarioOrderByStartsDesc(idUsuario)
+                .stream()
+                .map(this::toDTO)
+                .toList();
+    }
+
+    // Helpers
+    private MembresiaResponseDTO toDTO(Membresia m) {
+        return new MembresiaResponseDTO(
+                m.getId(),
+                m.getPlan(),
+                m.getStatus(),
+                m.isAutoRenew(),
+                m.getStartsAt(),
+                m.getEndsAt()
+        );
+    }
+
+    private void syncUserRole(Usuario user) {
+        boolean active = membresiaRepository.hasActiveMembership(user.getId_usuario(), Instant.now());
+        Rol desired = active ? Rol.PREMIUM : Rol.FREE;
+        if (user.getRol() != desired) {
+            user.setRol(desired);
+            usuarioRepository.save(user); // persiste el cambio de rol
+        }
+    }
+}


### PR DESCRIPTION
**1. Implementa la entidad Membresía y su relación Usuario (1:N) Membresía:**
- Crear membresía (MONTHLY/ANNUAL) simulando activación inmediata.
- Listar historial de membresías por usuario (orden desc).
- Cancelar membresía activa por ultima membresía o idMembresia del usuario.
- Sincronizar rol de Usuario a PREMIUM al activar y a FREE cuando no hay activas vigentes.

**2. Endpoints**
- POST /api/v1/usuarios/{idUsuario}/membresias
- GET /api/v1/usuarios/{idUsuario}/membresias
- PUT /api/v1/usuarios/{idUsuario}/membresias/{idMembresia}/cancelar

**3. Reglas de negocio**
- Un usuario no puede tener más de una membresía ACTIVA vigente.
- CANCELAR solo aplica a membresías en estado ACTIVE.
- Vigencia: startsAt < now < endsAt.

**4. Cambios principales**
- Modelos: Membresia (+ enums Plan, MembresiaStatus), hook List en Usuario.
- Repositorio: queries @query para evitar problemas con id_usuario.
- Servicios: create, list, cancel + syncUserRole.
- Controlador: MembresiaController con rutas.

**5. Pruebas (Postman)**
- Crear: POST /usuarios/{id}/membresias body { "plan":"MONTHLY","autoRenew":true } → 201.
- Listar: GET /usuarios/{id}/membresias → 200 (historial).
- Duplicado: repetir POST → 422/409 (RN activa vigente).
- Cancelar: PUT /usuarios/{id}/membresias/{mid}/cancelar → 200, status=CANCELED.
- Rol: GET /usuarios/{id} → role debe reflejar PREMIUM/FREE según vigencia.